### PR TITLE
feat: add observer package

### DIFF
--- a/observe/doc.go
+++ b/observe/doc.go
@@ -1,0 +1,28 @@
+/*
+Package observe implements a type that combines statter, logger and tracer.
+
+Example usage:
+
+	func New(c *cli.Context, svc, version string) (*observe.Observer, error) {
+		log, logCancel, err := NewLogger(c, svc)
+		if err != nil {
+			return nil, err
+		}
+
+		stats, statsCancel, err := NewStatter(c, log, svc)
+		if err != nil {
+			logCancel()
+			return nil, err
+		}
+
+		tracer, traceCancel, err := NewTracer(c, log, svc, version)
+		if err != nil {
+			logCancel()
+			statsCancel()
+			return nil, err
+		}
+
+		return observe.New(log, stats, tracer, traceCancel, statsCancel, logCancel), nil
+	}
+*/
+package observe

--- a/observe/observer.go
+++ b/observe/observer.go
@@ -1,0 +1,56 @@
+package observe
+
+import (
+	"io"
+	"time"
+
+	"github.com/hamba/logger/v2"
+	"github.com/hamba/statter/v2"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// Observer contains observability primitives.
+type Observer struct {
+	Log       *logger.Logger
+	Stats     *statter.Statter
+	TraceProv trace.TracerProvider
+
+	closeFns []func()
+}
+
+// New returns an observer with the given observability primitives.
+func New(log *logger.Logger, stats *statter.Statter, traceProv trace.TracerProvider, closeFns ...func()) *Observer {
+	return &Observer{
+		Log:       log,
+		Stats:     stats,
+		TraceProv: traceProv,
+		closeFns:  closeFns,
+	}
+}
+
+// Tracer returns a tracer with the given name and options.
+// If no trace provider has been set, this function will panic.
+func (o *Observer) Tracer(name string, opts ...trace.TracerOption) trace.Tracer {
+	if o.TraceProv == nil {
+		panic("calling tracer when no trace provider has been set")
+	}
+	return o.TraceProv.Tracer(name, opts...)
+}
+
+// Close closes the observability primitives.
+func (o *Observer) Close() {
+	for _, cancel := range o.closeFns {
+		cancel()
+	}
+}
+
+// NewFake returns a fake observer that reports nothing.
+// This is useful for tests.
+func NewFake() *Observer {
+	log := logger.New(io.Discard, logger.LogfmtFormat(), logger.Error)
+	stats := statter.New(statter.DiscardReporter, time.Minute)
+	tracer := otel.GetTracerProvider()
+
+	return New(log, stats, tracer)
+}


### PR DESCRIPTION
## Goal of this PR

This PR adds the `observe` package to the `cmd` project, and updates the README accordingly with an example of how one might use it.

## How to test it

* It compiles
* Tests pass
* README changes make sense and are complete