### PR TITLE
feat: add trace headers flag

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -20,3 +20,15 @@ func Split(slice []string, sep string) ([][2]string, error) {
 
 	return res, nil
 }
+
+func sliceToMap(s []string) (map[string]string, error) {
+	m := make(map[string]string, len(s))
+	kvs, err := Split(s, "=")
+	if err != nil {
+		return nil, err
+	}
+	for _, kv := range kvs {
+		m[kv[0]] = kv[1]
+	}
+	return m, nil
+}

--- a/profile.go
+++ b/profile.go
@@ -90,14 +90,11 @@ func NewProfiler(c *cli.Context, svc string, log *logger.Logger) (*pyroscope.Pro
 		Path:   u.Path,
 	}
 
-	tags := map[string]string{}
+	var tags map[string]string
 	if pairs := c.StringSlice(FlagProfilingTags); len(pairs) > 0 {
-		strTags, err := Split(pairs, "=")
+		tags, err = sliceToMap(pairs)
 		if err != nil {
 			return nil, err
-		}
-		for _, kv := range strTags {
-			tags[kv[0]] = kv[1]
 		}
 	}
 

--- a/trace_test.go
+++ b/trace_test.go
@@ -17,6 +17,7 @@ func TestNewTracer(t *testing.T) {
 		exporter string
 		endpoint string
 		tags     []string
+		headers  []string
 		ratio    float64
 		wantErr  require.ErrorAssertionFunc
 	}{
@@ -39,6 +40,14 @@ func TestNewTracer(t *testing.T) {
 			exporter: "otlphttp",
 			endpoint: "localhost:1234",
 			tags:     []string{"cluster=test", "namespace=num"},
+			ratio:    1.0,
+			wantErr:  require.NoError,
+		},
+		{
+			name:     "with headers",
+			exporter: "otlphttp",
+			endpoint: "localhost:1234",
+			headers:  []string{"cluster=test", "namespace=num"},
 			ratio:    1.0,
 			wantErr:  require.NoError,
 		},
@@ -74,6 +83,7 @@ func TestNewTracer(t *testing.T) {
 			fs.String(cmd.FlagTracingExporter, test.exporter, "doc")
 			fs.String(cmd.FlagTracingEndpoint, test.endpoint, "doc")
 			fs.Var(cli.NewStringSlice(test.tags...), cmd.FlagTracingTags, "doc")
+			fs.Var(cli.NewStringSlice(test.headers...), cmd.FlagTracingHeaders, "doc")
 			fs.Float64(cmd.FlagTracingRatio, test.ratio, "doc")
 
 			log := logger.New(io.Discard, logger.LogfmtFormat(), logger.Error)


### PR DESCRIPTION
This PR adds a headers flag for traces. This is useful to add tenant ids to traces.