### PR TITLE
fix: move pyroscope debug to trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fatih/color v1.17.0
 	github.com/grafana/otel-profiling-go v0.5.1
 	github.com/grafana/pyroscope-go v1.1.1
-	github.com/hamba/logger/v2 v2.5.1
+	github.com/hamba/logger/v2 v2.6.0
 	github.com/hamba/statter/v2 v2.3.5
 	github.com/stretchr/testify v1.9.0
 	github.com/urfave/cli/v2 v2.27.2

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/grafana/pyroscope-go/godeltaprof v0.1.6 h1:nEdZ8louGAplSvIJi1HVp7kWvF
 github.com/grafana/pyroscope-go/godeltaprof v0.1.6/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 h1:/c3QmbOGMGTOumP2iT/rCwB7b0QDGLKzqOmktBjT+Is=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1/go.mod h1:5SN9VR2LTsRFsrEC6FHgRbTWrTHu6tqPeKxEQv15giM=
-github.com/hamba/logger/v2 v2.5.1 h1:EM+S6CPYIs66XmW9kK/RBghgtkLcO4kQWWPAlsIwNR4=
-github.com/hamba/logger/v2 v2.5.1/go.mod h1:b+y7XddZMTTSIjKdOOIHWlhg1hMoE9eKhanB9wPNLj0=
+github.com/hamba/logger/v2 v2.6.0 h1:73CPbhY5luRzITKeX8hhdL4K3jezsH8cyTYgcOl7JeA=
+github.com/hamba/logger/v2 v2.6.0/go.mod h1:JEikfAmI6C/vaSE8MSb4SXTgWclNSN6tmdyyLv3/ATA=
 github.com/hamba/statter/v2 v2.3.5 h1:qAFu+n4Q08LtrBdcBYexItfOoJJ16D/m/boq8fm5hn4=
 github.com/hamba/statter/v2 v2.3.5/go.mod h1:LS7DqETxoVpRraL3tn9O70zYCaVRL2A98SvZw/LZkAI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=

--- a/log.go
+++ b/log.go
@@ -25,7 +25,7 @@ var LogFlags = Flags{
 	&cli.StringFlag{
 		Name:    FlagLogLevel,
 		Value:   "info",
-		Usage:   "Specify the log level. e.g. 'debug', 'info', 'error'.",
+		Usage:   "Specify the log level. e.g. 'trace', 'debug', 'info', 'error'.",
 		EnvVars: []string{"LOG_LEVEL"},
 	},
 	&cli.StringSliceFlag{

--- a/profile.go
+++ b/profile.go
@@ -131,7 +131,7 @@ func (a pyroLogAdapter) Infof(format string, args ...any) {
 }
 
 func (a pyroLogAdapter) Debugf(format string, args ...any) {
-	a.log.Debug(fmt.Sprintf(format, args...))
+	a.log.Trace(fmt.Sprintf(format, args...))
 }
 
 func (a pyroLogAdapter) Errorf(format string, args ...any) {


### PR DESCRIPTION
Pyroscopes debug is very noisy. To reduce the noise, it has been moved to `trace` level of the logs.