### PR TITLE
chore: use golangci-lint fmt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,6 @@ jobs:
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          parallel: true
+          flag-name: go-${{ matrix.go-version }}
           path-to-lcov: coverage.lcov

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,12 @@ formatters:
   settings:
     gofumpt:
       extra-rules: true
+    gci:
+      sections:
+        - standard
+        - default
+        - blank
+        - dot
   exclusions:
     generated: lax
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Format all files
 fmt:
 	@echo "==> Formatting source"
-	@gofmt -s -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")
+	@golangci-lint fmt ./...
 	@echo "==> Done"
 .PHONY: fmt
 

--- a/log_test.go
+++ b/log_test.go
@@ -76,6 +76,5 @@ func TestNewLogger(t *testing.T) {
 
 			test.wantErr(t, err)
 		})
-
 	}
 }


### PR DESCRIPTION
## Goal of this PR

This uses golangci-lint for formatting.

## How did I test it?

<!-- A brief description the steps taken to test this pull request. -->
